### PR TITLE
#5 Removing need for end of stream and close flags

### DIFF
--- a/src/main/java/fi/iki/yak/ts/compression/gorilla/Compressor.java
+++ b/src/main/java/fi/iki/yak/ts/compression/gorilla/Compressor.java
@@ -77,9 +77,9 @@ public class Compressor {
      */
     public void close() {
         // These are selected to test interoperability and correctness of the solution, this can be read with go-tsz
-        out.writeBits(0x0F, 4);
-        out.writeBits(0xFFFFFFFF, 32);
-        out.writeBit(false);
+//        out.writeBits(0x0F, 4);
+//        out.writeBits(0xFFFFFFFF, 32);
+//        out.writeBit(false);
         out.flush();
     }
 

--- a/src/main/java/fi/iki/yak/ts/compression/gorilla/Decompressor.java
+++ b/src/main/java/fi/iki/yak/ts/compression/gorilla/Decompressor.java
@@ -18,9 +18,12 @@ public class Decompressor {
     private boolean endOfStream = false;
 
     private BitInput in;
+	private int pairCount;
+	private int counter;
 
-    public Decompressor(BitInput input) {
+    public Decompressor(BitInput input, int pairCount) {
         in = input;
+		this.pairCount = pairCount;
         readHeader();
     }
 
@@ -42,19 +45,24 @@ public class Decompressor {
     }
 
     private void next() {
-        if (storedTimestamp == 0) {
+    	if (counter < pairCount) {
+           if (storedTimestamp == 0) {
             // First item to read
-            storedDelta = in.getLong(Compressor.FIRST_DELTA_BITS);
-            if(storedDelta == (1<<27) - 1) {
-                endOfStream = true;
-                return;
-            }
-            storedVal = in.getLong(64);
-            storedTimestamp = blockTimestamp + storedDelta;
-        } else {
-            nextTimestamp();
-            nextValue();
-        }
+               storedDelta = in.getLong(Compressor.FIRST_DELTA_BITS);
+//            if(storedDelta == (1<<27) - 1) {
+//                endOfStream = true;
+//                return;
+//            }
+               storedVal = in.getLong(64);
+               storedTimestamp = blockTimestamp + storedDelta;
+           } else {
+               nextTimestamp();
+               nextValue();
+           }
+           counter++;
+    	}else {
+    		endOfStream = true;
+    	}
     }
 
     private int bitsToRead() {

--- a/src/main/java/fi/iki/yak/ts/compression/gorilla/benchmark/EncodingBenchmark.java
+++ b/src/main/java/fi/iki/yak/ts/compression/gorilla/benchmark/EncodingBenchmark.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -93,7 +92,7 @@ public class EncodingBenchmark {
     public void decodingDoubleBenchmark(DataGenerator dg, Blackhole bh) throws Exception {
         ByteBuffer duplicate = dg.compressedBuffer.duplicate();
         ByteBufferBitInput input = new ByteBufferBitInput(duplicate);
-        Decompressor d = new Decompressor(input);
+        Decompressor d = new Decompressor(input, dg.amountOfPoints);
         Pair pair;
         while((pair = d.readPair()) != null) {
             bh.consume(pair);

--- a/src/test/java/fi/iki/yak/ts/compression/gorilla/EncodeTest.java
+++ b/src/test/java/fi/iki/yak/ts/compression/gorilla/EncodeTest.java
@@ -48,7 +48,7 @@ public class EncodeTest {
         byteBuffer.flip();
 
         ByteBufferBitInput input = new ByteBufferBitInput(byteBuffer);
-        Decompressor d = new Decompressor(input);
+        Decompressor d = new Decompressor(input, pairs.length);
 
         // Replace with stream once decompressor supports it
         for(int i = 0; i < pairs.length; i++) {
@@ -97,7 +97,7 @@ public class EncodeTest {
         byteBuffer.flip();
 
         ByteBufferBitInput input = new ByteBufferBitInput(byteBuffer);
-        Decompressor d = new Decompressor(input);
+        Decompressor d = new Decompressor(input, 5);
 
         // Replace with stream once decompressor supports it
         for(int i = 0; i < 5; i++) {
@@ -144,7 +144,7 @@ public class EncodeTest {
         byteBuffer.flip();
 
         ByteBufferBitInput input = new ByteBufferBitInput(byteBuffer);
-        Decompressor d = new Decompressor(input);
+        Decompressor d = new Decompressor(input, amountOfPoints);
 
         for(int i = 0; i < amountOfPoints; i++) {
             long tStamp = bb.getLong();
@@ -173,7 +173,7 @@ public class EncodeTest {
         byteBuffer.flip();
 
         ByteBufferBitInput input = new ByteBufferBitInput(byteBuffer);
-        Decompressor d = new Decompressor(input);
+        Decompressor d = new Decompressor(input, 0);
 
         assertNull(d.readPair());
     }
@@ -213,7 +213,7 @@ public class EncodeTest {
         byteBuffer.flip();
 
         ByteBufferBitInput input = new ByteBufferBitInput(byteBuffer);
-        Decompressor d = new Decompressor(input);
+        Decompressor d = new Decompressor(input, amountOfPoints);
 
         for(int i = 0; i < amountOfPoints; i++) {
             long tStamp = bb.getLong();


### PR DESCRIPTION
@burmanm here's a patch for removing end of stream marker by using a count instead. Number of messages written should be stored by the user somewhere which can be referenced when reading.

Have also modified the unit tests accordingly. This for the issue #5 