### PR TITLE
closes #12 - Create copy constructors for LongArrayOutput and ByteBuf…

### DIFF
--- a/src/main/java/fi/iki/yak/ts/compression/gorilla/ByteBufferBitOutput.java
+++ b/src/main/java/fi/iki/yak/ts/compression/gorilla/ByteBufferBitOutput.java
@@ -21,6 +21,20 @@ public class ByteBufferBitOutput implements BitOutput {
         this(DEFAULT_ALLOCATION);
     }
 
+    /*
+     * Creates a deep copy of this object
+     */
+    public ByteBufferBitOutput(ByteBufferBitOutput other) {
+        ByteBuffer otherBB = other.getByteBuffer();
+        this.bb = ByteBuffer.allocateDirect(otherBB.capacity());
+        otherBB.flip();
+        this.bb.put(otherBB);
+        this.bb.limit(bb.capacity());
+        otherBB.limit(otherBB.capacity());
+        this.b = other.b;
+        this.bitsLeft = other.bitsLeft;
+    }
+
     /**
      * Give an initialSize different than DEFAULT_ALLOCATIONS. Recommended to use values which are dividable by 4096.
      *

--- a/src/main/java/fi/iki/yak/ts/compression/gorilla/LongArrayOutput.java
+++ b/src/main/java/fi/iki/yak/ts/compression/gorilla/LongArrayOutput.java
@@ -1,5 +1,7 @@
 package fi.iki.yak.ts.compression.gorilla;
 
+import java.util.Arrays;
+
 /**
  * An implementation of BitOutput interface that uses on-heap long array.
  *
@@ -35,6 +37,15 @@ public class LongArrayOutput implements BitOutput {
         }
     }
 
+    /*
+     * Creates a deep copy of this object
+     */
+    public LongArrayOutput(LongArrayOutput other) {
+        this.longArray = Arrays.copyOf(other.longArray, other.longArray.length);
+        this.position = other.position;
+        this.lB = other.lB;
+        this.bitsLeft = other.bitsLeft;
+    }
 
     /**
      * Creates a new ByteBufferBitOutput with a default allocated size of 4096 bytes.


### PR DESCRIPTION
Provide a mechanism to get an exact copy of each BitOutput implementation.

If a user keeps a reference to the BitOutput implementation passed to a Compressor/GorillaCompressor, this will allow an exact copy to be made, finalized (as if Compressor.close() was called), and passed to a Decompressor/GorillaDecompressor without affecting the original Compressor/GorillaCompressor.

Useful in a production environment where we want to read the contents of the Compressor/GorillaCompressor but are not ready to close.